### PR TITLE
use fully-qualified rkcommon::math::rsqrt to avoid overload ambiguity

### DIFF
--- a/tests/math/test_Quaternion.cpp
+++ b/tests/math/test_Quaternion.cpp
@@ -187,7 +187,7 @@ template <typename T>
 inline void test_slerp()
 {
   typename T::Scalar two = 2;
-  REQUIRE(CmpT(slerp(.5f, T(1, 0, 0, 0), T(0, 1, 0, 0)), T(rsqrt(two), rsqrt(two), 0, 0)));
+  REQUIRE(CmpT(slerp(.5f, T(1, 0, 0, 0), T(0, 1, 0, 0)), T(rkcommon::math::rsqrt(two), rkcommon::math::rsqrt(two), 0, 0)));
 }
 
 TEST_CASE("Quaternion functions", "[quat]")

--- a/tests/math/test_rkmath.cpp
+++ b/tests/math/test_rkmath.cpp
@@ -49,8 +49,8 @@ TEST_CASE("rkmath rcp_safe function", "[rkmath]")
 template <typename T>
 inline void test_rsqrt()
 {
-  REQUIRE(CmpT<T>(rsqrt(T(1)), T(1)));
-  REQUIRE(CmpT<T>(rsqrt(T(4)), T(.5)));
+  REQUIRE(CmpT<T>(rkcommon::math::rsqrt(T(1)), T(1)));
+  REQUIRE(CmpT<T>(rkcommon::math::rsqrt(T(4)), T(.5)));
 }
 
 TEST_CASE("rkmath rsqrt function", "[rkmath]")


### PR DESCRIPTION
Explicitly calling rkcommon::math::rsqrt() prevents conflict with the standard rsqrt(double) declared in bits/mathcalls.h, fixing the build error in Quaternion tests.